### PR TITLE
Fix name 'open' is not defined and logjuicer folder error

### DIFF
--- a/rcav2/__main__.py
+++ b/rcav2/__main__.py
@@ -22,7 +22,7 @@ def usage():
     return parser.parse_args()
 
 
-async def amain():
+async def run(args, env):
     args = usage()
     env = rcav2.env.Env(args.debug)
     if args.local_logjuicer:
@@ -40,6 +40,15 @@ async def amain():
         elif event == "usage":
             print()
             env.log.info("Request usage: %s -> %s", message["input"], message["output"])
+
+
+async def amain():
+    args = usage()
+    env = rcav2.env.Env(args.debug)
+    try:
+        await run(args, env)
+    finally:
+        env.close()
 
 
 def main():

--- a/rcav2/env.py
+++ b/rcav2/env.py
@@ -20,9 +20,10 @@ class Env:
         self.auth = HTTPSPNEGOAuth(mutual_authentication=OPTIONAL)
         self.log = logging.getLogger("rcav2")
 
-    def __del__(self):
+    def close(self):
         if self.cookie:
-            open(".cookie", "w").write(self.cookie)
+            with open(".cookie", "w") as f:
+                f.write(self.cookie)
 
 
 def make_httpx_client() -> httpx.AsyncClient:


### PR DESCRIPTION
- There was a 'name 'open' is not defined' error trying to get the .cookie that was breaking the usage of the rcav2 via CLI
- There was an error about not existing logjuicer folder. Now we have logjuicer.py
- Updated TODO 'handle creating remote report' to use the existing get_remote_report