### PR TITLE
Update files to allow importing rcav2 in other projects after build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "rcav2"
 version = "0.1.0"
 license = "Apache-2.0"
-description = "RCA MCP"
+description = "MCP Tool used to identify, understand and deliver fast and accurate root cause analysis of Zuul CI Build failures."
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
@@ -12,12 +12,12 @@ dependencies = [
     "httpx-gssapi>=0.4",
     "httpx-ws>=0.7.2",
     "sqlalchemy>=2.0.43",
+    "llm>=0.27.1",
+    "llm-gemini>=0.25",
 ]
 
 [dependency-groups]
 dev = [
-    "llm>=0.27.1",
-    "llm-gemini>=0.25",
     "mypy>=1.18.1",
     "pytest>=8.4.1",
     "ruff>=0.11.12",
@@ -29,3 +29,7 @@ build-backend = "hatchling.build"
 
 [project.scripts]
 rcav2 = "rcav2.__main__:main"
+
+[project.urls]
+Homepage = "https://github.com/rca-mcp/rca-mcp"
+Repository = "https://github.com/rca-mcp/rca-mcp"

--- a/rcav2/__init__.py
+++ b/rcav2/__init__.py
@@ -1,1 +1,9 @@
+# Copyright © 2025 Red Hat
+# SPDX-License-Identifier: Apache-2.0
 
+__version__ = "0.1.0"
+
+from .env import Env
+from .model import query
+
+__all__ = ["Env", "query"]

--- a/rcav2/config.py
+++ b/rcav2/config.py
@@ -2,7 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 
-SF_DOMAIN = os.environ["SF_DOMAIN"]
+try:
+    SF_DOMAIN = os.environ["SF_DOMAIN"]
+except KeyError:
+    raise ValueError("The SF_DOMAIN environment variable must be set") from None
+
+
 SF_URL = f"https://{SF_DOMAIN}"
 DEFAULT_MODEL = "gemini-2.5-flash"
 DEFAULT_SYSTEM_PROMPT = (

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -813,13 +813,13 @@ dependencies = [
     { name = "httpx" },
     { name = "httpx-gssapi" },
     { name = "httpx-ws" },
+    { name = "llm" },
+    { name = "llm-gemini" },
     { name = "sqlalchemy" },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "llm" },
-    { name = "llm-gemini" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
@@ -832,13 +832,13 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "httpx-gssapi", specifier = ">=0.4" },
     { name = "httpx-ws", specifier = ">=0.7.2" },
+    { name = "llm", specifier = ">=0.27.1" },
+    { name = "llm-gemini", specifier = ">=0.25" },
     { name = "sqlalchemy", specifier = ">=2.0.43" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "llm", specifier = ">=0.27.1" },
-    { name = "llm-gemini", specifier = ">=0.25" },
     { name = "mypy", specifier = ">=1.18.1" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "ruff", specifier = ">=0.11.12" },


### PR DESCRIPTION
- Updated __init__ importing the base modules to avoid error
- Moved llm and llm-gemini to dependencies to avoid error when installing in other project