### PR TITLE
Centralize configuration in config.py

### DIFF
--- a/rcav2/__main__.py
+++ b/rcav2/__main__.py
@@ -9,7 +9,7 @@ import rcav2.logjuicer
 import rcav2.env
 import rcav2.model
 import rcav2.prompt
-from rcav2.config import DEFAULT_MODEL, DEFAULT_SYSTEM_PROMPT
+from rcav2.config import DEFAULT_MODEL, DEFAULT_SYSTEM_PROMPT, COOKIE_FILE
 
 
 def usage():
@@ -23,7 +23,6 @@ def usage():
 
 
 async def run(args, env: rcav2.env.Env):
-    env = rcav2.env.Env(args.debug)
     if args.local_logjuicer:
         report = await rcav2.logjuicer.get_report(env, args.URL)
     else:
@@ -43,7 +42,7 @@ async def run(args, env: rcav2.env.Env):
 
 async def amain():
     args = usage()
-    env = rcav2.env.Env(args.debug)
+    env = rcav2.env.Env(args.debug, cookie_path=COOKIE_FILE)
     try:
         await run(args, env)
     finally:

--- a/rcav2/api.py
+++ b/rcav2/api.py
@@ -15,7 +15,7 @@ import rcav2.model
 import rcav2.prompt
 import rcav2.database
 from rcav2.worker import Pool, Worker, Job
-from rcav2.config import DEFAULT_MODEL, DEFAULT_SYSTEM_PROMPT
+from rcav2.config import DEFAULT_MODEL, DEFAULT_SYSTEM_PROMPT, DATABASE_FILE
 
 
 class RCAJob(Job):
@@ -61,9 +61,9 @@ class RCAJob(Job):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # setup
-    app.state.env = rcav2.env.Env(debug=True)
+    app.state.env = rcav2.env.Env(debug=True, cookie_path=None)
     app.state.worker_pool = Pool(2)
-    app.state.db = rcav2.database.create(".db.sqlite3")
+    app.state.db = rcav2.database.create(DATABASE_FILE)
     yield
     # teardown
     await app.state.worker_pool.stop()

--- a/rcav2/config.py
+++ b/rcav2/config.py
@@ -13,3 +13,8 @@ DEFAULT_MODEL = "gemini-2.5-flash"
 DEFAULT_SYSTEM_PROMPT = (
     "You are a CI engineer, your goal is to find the RCA of this build failure."
 )
+CA_BUNDLE_PATH = os.environ.get(
+    "CA_BUNDLE_PATH", "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+)
+COOKIE_FILE = os.environ.get("COOKIE_FILE", ".cookie")
+DATABASE_FILE = os.environ.get("DATABASE_FILE", ".db.sqlite3")

--- a/rcav2/env.py
+++ b/rcav2/env.py
@@ -5,42 +5,48 @@ import ssl
 import httpx
 import pathlib
 import logging
+import time
 from httpx_gssapi import HTTPSPNEGOAuth, OPTIONAL  # type: ignore
-from rcav2.config import SF_DOMAIN
+from rcav2.config import SF_DOMAIN, CA_BUNDLE_PATH
 
 
 class Env:
     """The RCAv2 application environment"""
 
-    def __init__(self, debug):
+    def __init__(self, debug, cookie_path: str | None = None):
         lvl = logging.DEBUG if debug else logging.INFO
         logging.basicConfig(format="%(asctime)s %(levelname)9s %(message)s", level=lvl)
         self.cookie = None
-        self.httpx = make_httpx_client()
+        self.cookie_path = cookie_path
+        self.httpx = make_httpx_client(cookie_path)
         self.auth = HTTPSPNEGOAuth(mutual_authentication=OPTIONAL)
         self.log = logging.getLogger("rcav2")
 
     def close(self):
-        if self.cookie:
-            with open(".cookie", "w") as f:
+        if self.cookie and self.cookie_path:
+            with open(self.cookie_path, "w") as f:
                 f.write(self.cookie)
 
 
-def make_httpx_client() -> httpx.AsyncClient:
+def make_httpx_client(cookie_path: str | None) -> httpx.AsyncClient:
     """Setup the httpx client using local CA."""
     # Load local CA
     verify = True
-    local_ca = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
-    if pathlib.Path(local_ca).exists():
-        verify = ssl.create_default_context(cafile=local_ca)  # type: ignore
+    if pathlib.Path(CA_BUNDLE_PATH).exists():
+        verify = ssl.create_default_context(cafile=CA_BUNDLE_PATH)  # type: ignore
 
     # Restore cookies
     cookies = httpx.Cookies()
-    try:
-        cookie = open(".cookie").read()
-        cookies.set("mod_auth_openidc_session", cookie, domain=SF_DOMAIN)
-    except FileNotFoundError:
-        pass
+    if cookie_path:
+        cookie_file = pathlib.Path(cookie_path)
+        try:
+            if time.time() - cookie_file.stat().st_mtime > 24 * 3600:
+                cookie_file.unlink()
+            else:
+                cookie = cookie_file.read_text()
+                cookies.set("mod_auth_openidc_session", cookie, domain=SF_DOMAIN)
+        except FileNotFoundError:
+            pass
 
     # Create the client
     return httpx.AsyncClient(follow_redirects=True, verify=verify, cookies=cookies)


### PR DESCRIPTION
The CA_BUNDLE_PATH was giving an error since the certificate can be located in a different place. Moving the database, cookie and ca_cert path into the config.py keeping the default values we had.
Check and refresh the cookie if necessary after 24 hours.